### PR TITLE
Add MPC wallet for onramp and offramp test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ next-env.d.ts
 
 # CDP API keys
 api_keys/*.json
+wallet_seed/*json

--- a/app/components/TransferCrypto.tsx
+++ b/app/components/TransferCrypto.tsx
@@ -1,7 +1,7 @@
 import { Textarea } from "@nextui-org/input";
 import { Button, Card, Link } from "@nextui-org/react";
 import { useState, useCallback, useEffect, useMemo } from "react";
-import { user_id } from "../../app_id/app_id.json";
+import appInfo from "../../app_id/app_id.json";
 import { getSellTransactionStatus, createTransfer } from "../utils/queries";
 
 export default function TransferCryptoBox() {
@@ -15,12 +15,10 @@ export default function TransferCryptoBox() {
   useEffect(() => {
     const getOfframpTransaction = async () => {
       const transaction = await getSellTransactionStatus({
-        partner_user_id: user_id,
+        partner_user_id: appInfo.user_id,
       });
       try {
         if (transaction) {
-          console.log(transaction);
-          console.log(transaction.asset);
           setAmount(+transaction.sell_amount.value);
           setAsset(transaction.asset);
           // format the network name (e.g. "network/base-mainnet" -> "base-mainnet")

--- a/app/components/TransferCrypto.tsx
+++ b/app/components/TransferCrypto.tsx
@@ -1,0 +1,96 @@
+import { Textarea } from "@nextui-org/input";
+import { Button, Card, Link } from "@nextui-org/react";
+import { useState, useCallback, useEffect, useMemo } from "react";
+import { user_id } from "../../app_id/app_id.json";
+import { getSellTransactionStatus, createTransfer } from "../utils/queries";
+
+export default function TransferCryptoBox() {
+  const [amount, setAmount] = useState(0);
+  const [asset, setAsset] = useState("");
+  const [network, setNetwork] = useState("");
+  const [destination, setDestination] = useState("");
+  const [transfer_link, setTransferLink] = useState("");
+  const [transfer_result, setTransferResult] = useState("");
+
+  useEffect(() => {
+    const getOfframpTransaction = async () => {
+      const transaction = await getSellTransactionStatus({
+        partner_user_id: user_id,
+      });
+      try {
+        if (transaction) {
+          console.log(transaction);
+          console.log(transaction.asset);
+          setAmount(+transaction.sell_amount.value);
+          setAsset(transaction.asset);
+          // format the network name (e.g. "network/base-mainnet" -> "base-mainnet")
+          setNetwork(transaction.network.split("/")[1]);
+          setDestination(transaction.to_address);
+        } else {
+          setAmount(0);
+          setAsset("");
+          setNetwork("");
+          setDestination("");
+        }
+      } catch (error) {
+        alert(error);
+        console.error(error);
+      }
+    };
+    getOfframpTransaction();
+  });
+
+  const createTransferWrapper = useCallback(async () => {
+    let response = await createTransfer({
+      network: network,
+      amount: amount,
+      assetId: asset,
+      destination: destination,
+    });
+    if (response.id != "") {
+      setTransferLink(response.txh);
+      let result = `Transfer Id: ${response.id}, status: ${response.status}`;
+      setTransferResult(result);
+    } else {
+      setTransferResult("");
+      setTransferLink("");
+    }
+  }, [network]);
+
+  const offramp_transaction_details = useMemo(() => {
+    if (asset == "") return "No active offramp transaction";
+    return `Send  ${amount} ${asset} on ${network}\n` + `To ${destination}`;
+  }, [asset]);
+
+  return (
+    <div className="flex flex-col w-full space-y-5">
+      <Card id="Offramp transfer">
+        <div>
+          <section className="flex flex-row justify-between gap-10 p-10 pt-5">
+            <div className="flex flex-col space-y-5 w-full">
+              <Textarea
+                className="flex-auto"
+                isReadOnly
+                label="offramp url"
+                variant="bordered"
+                value={offramp_transaction_details}
+              />
+              <Button
+                className="w-full"
+                isDisabled={network == "" || asset == "" || amount == 0}
+                onClick={createTransferWrapper}
+              >
+                {" "}
+                Transfer{" "}
+              </Button>
+              <Link color="success" href={transfer_link} isExternal>
+                {" "}
+                <b>{transfer_result}</b>{" "}
+              </Link>
+            </div>
+          </section>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/app/components/WalletBox.tsx
+++ b/app/components/WalletBox.tsx
@@ -1,0 +1,242 @@
+import { Textarea } from "@nextui-org/input";
+import { Button, Card, Link, Select, SelectItem } from "@nextui-org/react";
+import { useState, useCallback, ChangeEvent, useMemo } from "react";
+import { project_id, user_id } from "../../app_id/app_id.json";
+import { generateWallet } from "../utils/queries";
+import { NETWORK_LIST } from "../utils/networks";
+
+export default function WalletBox() {
+  const [address, setAddress] = useState("");
+  const [network, setNetwork] = useState("");
+  const [balance, setBalance] = useState("");
+  const [onramp_link, setOnrampLink] = useState("");
+  const [offramp_link, setOfframpLink] = useState("");
+  const redirectUrl = "http://localhost:3000/wallet/sell";
+
+  const setNetworkOption = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      setNetwork(event.target.value);
+    },
+    []
+  );
+
+  const generateWalletWrapper = useCallback(async () => {
+    const wallet = await generateWallet({ network_id: network });
+    try {
+      if (wallet) {
+        console.log(wallet.balance);
+        setAddress(wallet.wallet_address);
+        setNetwork(wallet.network_id);
+        setBalance(wallet.balance);
+      } else {
+        setAddress("");
+        setNetwork("");
+        setBalance("");
+      }
+    } catch (error) {
+      alert(error);
+      console.error(error);
+    }
+  }, [network]);
+
+  const generateOnrampLink = useCallback(async () => {
+    let shorten_network = network.split("-")[0];
+    setOnrampLink(
+      `https://pay.coinbase.com/buy/select-asset?appId=${project_id}` +
+        `&addresses={"${address}":["${shorten_network}"]}`
+    );
+  }, [address, network]);
+
+  const generateOfframpLink = useCallback(async () => {
+    let shorten_network = network.split("-")[0];
+    setOfframpLink(
+      `https://pay.coinbase.com/v3/offramp/input?appId=${project_id}` +
+        `&addresses={"${address}":["${shorten_network}"]}&redirectUrl=${redirectUrl}&partnerUserId=${user_id}`
+    );
+  }, [address, network, user_id]);
+
+  const launch_onramp = useCallback(() => {
+    open(onramp_link, "_blank", "popup,width=540,height=700");
+  }, [onramp_link]);
+
+  const launch_offramp = useCallback(() => {
+    open(offramp_link, "_blank", "popup,width=540,height=700");
+  }, [offramp_link]);
+
+  const wallet_address = useMemo(() => {
+    if (address.length == 0) return "Generate or Load a wallet";
+    return `${address}`;
+  }, [address]);
+
+  const wallet_balance = useMemo(() => {
+    if (balance.length == 0) return "Generate or Load a wallet";
+    return balance;
+  }, [balance]);
+
+  return (
+    <div className="flex flex-col w-full space-y-5">
+      <Card id="Offramp">
+        <div className="flex flex-col p-4 pb-5 gap-1">
+          <h1 className="font-bold underline">
+            {" "}
+            <Link
+              color="foreground"
+              href="https://docs.cdp.coinbase.com/mpc-wallet/docs/welcome"
+              isExternal
+            >
+              {" "}
+              Generate/Load a wallet:{" "}
+            </Link>{" "}
+          </h1>
+          <h2>
+            Generate Or Reload a{" "}
+            <b>
+              <Link
+                color="foreground"
+                href="https://docs.cdp.coinbase.com/mpc-wallet/docs/welcome"
+                isExternal
+              >
+                {" "}
+                MPC Wallet{" "}
+              </Link>{" "}
+            </b>
+            with a supporting blockhain network.
+          </h2>
+        </div>
+        <div>
+          <section className="flex flex-row justify-between gap-10 p-10 pt-5">
+            <div className="flex flex-col space-y-5 w-full">
+              <Select
+                className="flex w-full"
+                name="blockchain-option"
+                label="Blockchain Network"
+                placeholder="Select a network"
+                onChange={setNetworkOption}
+                items={NETWORK_LIST}
+                isRequired
+              >
+                {(curr) => <SelectItem key={curr.id}>{curr.name}</SelectItem>}
+              </Select>
+              <Button
+                className="w-full"
+                onClick={generateWalletWrapper}
+                isDisabled={network == ""}
+              >
+                Generate Wallet{" "}
+              </Button>
+            </div>
+
+            <div className="flex flex-col space-y-5 w-full">
+              <Textarea
+                className="flex-auto"
+                isReadOnly
+                label="wallet address"
+                variant="bordered"
+                rows={1}
+                value={wallet_address}
+              />
+              <Textarea
+                className="flex-auto"
+                isReadOnly
+                label="wallet balance"
+                variant="bordered"
+                rows={1}
+                value={wallet_balance}
+              />
+            </div>
+          </section>
+        </div>
+      </Card>
+      <Card id="Onramp">
+        <div className="flex flex-col p-4 pb-5 gap-1">
+          <h1 className="font-bold underline">
+            {" "}
+            <Link
+              color="foreground"
+              href="https://docs.cdp.coinbase.com/onramp/docs/api-initializing/"
+              isExternal
+            >
+              {" "}
+              Generate an Onramp Link{" "}
+            </Link>{" "}
+          </h1>
+        </div>
+        <div>
+          <section className="flex flex-row justify-between gap-10 p-10 pt-5">
+            <div className="flex flex-col space-y-5 w-full">
+              <Button
+                className="w-full"
+                onClick={generateOnrampLink}
+                isDisabled={address == ""}
+              >
+                Generate URL{" "}
+              </Button>
+              <Button
+                className="w-full"
+                onClick={launch_onramp}
+                isDisabled={onramp_link == ""}
+              >
+                {" "}
+                Launch Onramp{" "}
+              </Button>
+            </div>
+            <div className="flex flex-col space-y-5 w-full">
+              <Textarea
+                className="flex-auto"
+                isReadOnly
+                label="onramp url"
+                variant="bordered"
+                value={onramp_link}
+              />
+            </div>
+          </section>
+        </div>
+      </Card>
+      <Card id="Offramp">
+        <div className="flex flex-col p-4 pb-5 gap-1">
+          <h1 className="font-bold underline">
+            {" "}
+            <Link
+              color="foreground"
+              href="https://docs.cdp.coinbase.com/onramp/docs/api-initializing/"
+              isExternal
+            >
+              {" "}
+              Generate an Offramp Link:{" "}
+            </Link>{" "}
+          </h1>
+        </div>
+        <div>
+          <section className="flex flex-row justify-between gap-10 p-10 pt-5">
+            <div className="flex flex-col space-y-5 w-full">
+              <Button
+                className="w-full"
+                onClick={generateOfframpLink}
+                isDisabled={address == ""}
+              >
+                Generate URL{" "}
+              </Button>
+              <Button
+                className="w-full"
+                onClick={launch_offramp}
+                isDisabled={offramp_link == ""}
+              >
+                {" "}
+                Launch Offramp{" "}
+              </Button>
+            </div>
+            <div className="flex flex-col space-y-5 w-full">
+              <Textarea
+                className="flex-auto"
+                isReadOnly
+                label="offramp url"
+                variant="bordered"
+                value={offramp_link}
+              />
+            </div>
+          </section>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/app/components/WalletBox.tsx
+++ b/app/components/WalletBox.tsx
@@ -1,7 +1,7 @@
 import { Textarea } from "@nextui-org/input";
 import { Button, Card, Link, Select, SelectItem } from "@nextui-org/react";
 import { useState, useCallback, ChangeEvent, useMemo } from "react";
-import { project_id, user_id } from "../../app_id/app_id.json";
+import appInfo from "../../app_id/app_id.json";
 import { generateWallet } from "../utils/queries";
 import { NETWORK_LIST } from "../utils/networks";
 
@@ -42,7 +42,7 @@ export default function WalletBox() {
   const generateOnrampLink = useCallback(async () => {
     let shorten_network = network.split("-")[0];
     setOnrampLink(
-      `https://pay.coinbase.com/buy/select-asset?appId=${project_id}` +
+      `https://pay.coinbase.com/buy/select-asset?appId=${appInfo.project_id}` +
         `&addresses={"${address}":["${shorten_network}"]}`
     );
   }, [address, network]);
@@ -50,10 +50,10 @@ export default function WalletBox() {
   const generateOfframpLink = useCallback(async () => {
     let shorten_network = network.split("-")[0];
     setOfframpLink(
-      `https://pay.coinbase.com/v3/offramp/input?appId=${project_id}` +
-        `&addresses={"${address}":["${shorten_network}"]}&redirectUrl=${redirectUrl}&partnerUserId=${user_id}`
+      `https://pay.coinbase.com/v3/sell/input?appId=${appInfo.project_id}` +
+        `&addresses={"${address}":["${shorten_network}"]}&redirectUrl=${redirectUrl}&partnerUserId=${appInfo.user_id}`
     );
-  }, [address, network, user_id]);
+  }, [address, network, appInfo.user_id]);
 
   const launch_onramp = useCallback(() => {
     open(onramp_link, "_blank", "popup,width=540,height=700");

--- a/app/utils/blockchains.ts
+++ b/app/utils/blockchains.ts
@@ -1,5 +1,9 @@
 export const BLOCKCHAIN_LIST = [
     {
+      name: "Base",
+      id: "base"
+    },
+    {
       name: "Bitcoin",
       id: "bitcoin"
     },
@@ -62,10 +66,6 @@ export const BLOCKCHAIN_LIST = [
     {
       name: "Bitcoin Cash",
       id: "bitcoincash"
-    },
-    {
-      name: "Base",
-      id: "base"
     },
     {
       name: "Flow",

--- a/app/utils/networks.ts
+++ b/app/utils/networks.ts
@@ -1,0 +1,22 @@
+export const NETWORK_LIST = [
+  {
+    name: "Base Sepolia",
+    id: "base-sepolia",
+  },
+  {
+    name: "Base Mainnet",
+    id: "base-mainnet",
+  },
+  {
+    name: "Ethereum Mainnet",
+    id: "ethereum-mainnet",
+  },
+  {
+    name: "Ethereum Holesky",
+    id: "ethereum-holesky",
+  },
+  {
+    name: "Polygon Mainnet",
+    id: "polygon-mainnet",
+  },
+];

--- a/app/utils/queries.ts
+++ b/app/utils/queries.ts
@@ -8,6 +8,12 @@ import {
   SellOptionsResponse,
   SellQuoteRequest,
   SellQuoteResponse,
+  GenerateWalletResponse,
+  GenerateWalletRequest,
+  SellTransactionStatusRequest,
+  SellTransactionStatusResponse,
+  CreateTransferRequest,
+  CreateTransferResponse,
 } from "./types";
 
 export async function generateSecureToken({
@@ -138,7 +144,7 @@ export async function generateSellOptions({
     }
 
     const json: SellOptionsResponse = await response.json();
-    const  cashcout_currencies = json.cashout_currencies.map((currency) => ({
+    const cashcout_currencies = json.cashout_currencies.map((currency) => ({
       name: currency.id,
     }));
     const sell_currencies = json.sell_currencies.map((currency) => ({
@@ -164,6 +170,72 @@ export async function generateSellQuote(request: SellQuoteRequest) {
     }
 
     const json: SellQuoteResponse = await response.json();
+    return json;
+  } catch (error) {
+    throw error;
+  }
+}
+
+export async function generateWallet(request: GenerateWalletRequest) {
+  try {
+    console.log(`generateWallet`);
+    const response = await fetch("/api/create-wallet-api", {
+      method: "POST",
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      console.log(await response.text());
+      throw new Error("Failed to create wallet");
+    }
+
+    const json: GenerateWalletResponse = await response.json();
+    return json;
+  } catch (error) {
+    throw error;
+  }
+}
+
+export async function getSellTransactionStatus(
+  request: SellTransactionStatusRequest
+) {
+  try {
+    console.log("getSellTransactionStatus");
+    const response = await fetch("/api/sell-transaction-status-api", {
+      method: "POST",
+      body: JSON.stringify(request),
+    });
+    console.log(response);
+    if (!response.ok) {
+      console.log(await response.text());
+      throw new Error("Failed to fetch sell transaction");
+    }
+
+    const transactionResponse: SellTransactionStatusResponse = await response.json();
+    for (var transaction of transactionResponse.transactions) {
+      if ((transaction.status = 3)) return transaction;
+    }
+    return undefined;
+  } catch (error) {
+    throw error;
+  }
+}
+
+export async function createTransfer(request: CreateTransferRequest) {
+  try {
+    console.log(`createTransfer`);
+    const response = await fetch("/api/create-transfer-api", {
+      method: "POST",
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      console.log(await response.text());
+      throw new Error("Failed to create transfer");
+    }
+    const json: CreateTransferResponse = await response.json();
+    console.log(`response ${json.id}`);
+
     return json;
   } catch (error) {
     throw error;

--- a/app/utils/queries.ts
+++ b/app/utils/queries.ts
@@ -205,7 +205,7 @@ export async function getSellTransactionStatus(
       method: "POST",
       body: JSON.stringify(request),
     });
-    console.log(response);
+
     if (!response.ok) {
       console.log(await response.text());
       throw new Error("Failed to fetch sell transaction");
@@ -234,7 +234,6 @@ export async function createTransfer(request: CreateTransferRequest) {
       throw new Error("Failed to create transfer");
     }
     const json: CreateTransferResponse = await response.json();
-    console.log(`response ${json.id}`);
 
     return json;
   } catch (error) {

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -154,3 +154,45 @@ export type SellQuoteResponse = {
   sell_amount: { value: string; currency: string };
   quote_id: string;
 };
+
+export type GenerateWalletRequest = {
+  network_id: string;
+};
+export type GenerateWalletResponse = {
+  wallet_address: string;
+  network_id: string;
+  balance: string;
+};
+
+export type OfframpTransactions = {
+  transaction_id: string;
+  status: number;
+  asset: string;
+  network: string;
+  sell_amount: { value: string; currency: string };
+  total: { value: string; currency: string };
+  to_address: string;
+};
+
+export type SellTransactionStatusRequest = {
+  partner_user_id: string;
+};
+
+export type SellTransactionStatusResponse = {
+  transactions: OfframpTransactions[];
+  next_page_key: string;
+  total_count: number;
+};
+
+export type CreateTransferRequest = {
+  network: string;
+  amount: number;
+  assetId: string;
+  destination: string;
+};
+
+export type CreateTransferResponse = {
+  id: string;
+  status: string;
+  txh: string;
+};

--- a/app/wallet/page.tsx
+++ b/app/wallet/page.tsx
@@ -1,11 +1,7 @@
 "use client";
 import Image from "next/image";
-
-import { Tabs, Tab, Card, Link } from "@nextui-org/react";
-import SecureTokenBox from "./components/SecureTokenBox";
-import BuyQuoteBox from "./components/BuyQuoteBox";
-import SellQuoteBox from "./components/SellQuoteBox";
-import WalletBox from "./components/WalletBox";
+import { Card, Link } from "@nextui-org/react";
+import WalletBox from "../components/WalletBox";
 
 export default function Home() {
   return (
@@ -45,9 +41,8 @@ export default function Home() {
               inside your onramp-demo-app repo.
             </p>
             <p className="text-lg">
-              4. When creating your aggregator URL, first generate a buy config,
-              then buy options, and finally generate a buy quote. Only then, can
-              you input your wallet address and receive your One-Click-Buy link.
+              4. Copy the developer <b>project id</b> to{" "}
+              <b>app_id/app_id.json</b>, and add unique <b>user_id</b> for test
             </p>
           </div>
         </div>
@@ -65,20 +60,7 @@ export default function Home() {
       </Card>
 
       <div className="flex w-full flex-col gap-5">
-        <Tabs aria-label="Options">
-          <Tab key="wallet" title="Generate an Wallet for test">
-            <WalletBox />
-          </Tab>
-          <Tab key="genToken" title="Generate Onramp URL">
-            <SecureTokenBox />
-          </Tab>
-          <Tab key="buyQuote" title="Generate Onramp Aggregator URL">
-            <BuyQuoteBox />
-          </Tab>
-          <Tab key="sellQuote" title="Generate Offramp Aggregator URL">
-            <SellQuoteBox />
-          </Tab>
-        </Tabs>
+        <WalletBox />
       </div>
     </div>
   );

--- a/app/wallet/sell/page.tsx
+++ b/app/wallet/sell/page.tsx
@@ -1,0 +1,28 @@
+"use client";
+import Image from "next/image";
+
+import { Tabs, Tab, Card, Link } from "@nextui-org/react";
+import TransferCryptoBox from "../../components/TransferCrypto";
+
+export default function Home() {
+  return (
+    <div className="space-y-10 size-full">
+      <Card className="flex flex-row justify-between p-5 w-full">
+        <div>
+          <Image
+            src="/cdp.svg"
+            alt="Next.js Logo"
+            width={200}
+            height={37}
+            priority
+            className="flex flex-col"
+          />
+        </div>
+      </Card>
+
+      <div className="flex w-full flex-col gap-5">
+        <TransferCryptoBox />
+      </div>
+    </div>
+  );
+}

--- a/app_id/app_id.json
+++ b/app_id/app_id.json
@@ -1,0 +1,1 @@
+{ "project_id": "project_id", "user_id": "user_id" }

--- a/pages/api/create-transfer-api.ts
+++ b/pages/api/create-transfer-api.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { fetchWallet } from "./helpers";
+import { TimeoutError } from "@coinbase/coinbase-sdk";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const reqBody = JSON.parse(req.body);
+  let { wallet } = await fetchWallet(reqBody.network);
+  if (wallet != undefined) {
+    console.log(
+      `transfer ${reqBody.amount} ${reqBody.assetId.toLowerCase()} on ${
+        reqBody.network
+      } to ${reqBody.destination}`
+    );
+    let transfer = await wallet.createTransfer({
+      amount: reqBody.amount,
+      assetId: reqBody.assetId.toLowerCase(),
+      destination: reqBody.destination,
+      gasless: true,
+    });
+
+    // Wait for transfer to land on-chain.
+    try {
+      transfer = await transfer.wait();
+    } catch (err) {
+      if (err instanceof TimeoutError) {
+        console.log("Waiting for transfer timed out");
+      } else {
+        console.error("Error while waiting for transfer to complete: ", err);
+      }
+    }
+
+    // Check if transfer successfully completed on-chain
+    if (transfer.getStatus() === "complete") {
+      console.log("Transfer completed on-chain: ", transfer.toString());
+    } else {
+      console.error("Transfer failed on-chain: ", transfer.toString());
+    }
+    return res.json({
+      id: transfer.getId(),
+      status: transfer.getStatus(),
+      txh: transfer.getTransactionLink(),
+    });
+  }
+}

--- a/pages/api/create-wallet-api.ts
+++ b/pages/api/create-wallet-api.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { fetchWallet } from "./helpers";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const reqBody = JSON.parse(req.body);
+  let { wallet } = await fetchWallet(reqBody.network_id);
+  if (wallet != undefined) {
+    let addresses = await wallet.listAddresses();
+    let address = addresses[0].getId();
+    // Get the wallet's balance.
+    let balance = await wallet.listBalances();
+
+    return res.json({
+      wallet_address: addresses[0].getId(),
+      network_id: addresses[0].getNetworkId(),
+      balance: balance.toString(),
+    });
+  }
+}

--- a/pages/api/helpers.ts
+++ b/pages/api/helpers.ts
@@ -1,19 +1,27 @@
 import { SignOptions, sign } from "jsonwebtoken";
 import crypto from "crypto";
 import { NextApiResponse } from "next";
+import fs from "fs";
+import { Coinbase, Wallet, CoinbaseOptions } from "@coinbase/coinbase-sdk";
 
 export type createRequestParams = {
   request_method: "GET" | "POST";
   request_path: string;
 };
 
+export async function fetchApiCredentials() {
+  const key = await import("../../api_keys/cdp_api_key.json");
+  const key_name = key.name;
+  const key_secret = key.privateKey;
+
+  return { key_name, key_secret };
+}
+
 export async function createRequest({
   request_method,
   request_path,
 }: createRequestParams) {
-  const key = await import("../../api_keys/cdp_api_key.json");
-  const key_name = key.name;
-  const key_secret = key.privateKey;
+  const { key_name, key_secret } = await fetchApiCredentials();
   const host = "api.developer.coinbase.com";
 
   const url = `https://${host}${request_path}`;
@@ -75,4 +83,42 @@ export async function fetchOnrampRequest({
       console.log("Caught error: ", error);
       res.status(500);
     });
+}
+
+export async function fetchWallet(network_id: string) {
+  const { key_name, key_secret } = await fetchApiCredentials();
+  const coinbaseOptions: CoinbaseOptions = {
+    apiKeyName: key_name,
+    privateKey: key_secret,
+  };
+  const coinbase = new Coinbase(coinbaseOptions);
+  const seedFilePath = "wallet_seed/" + network_id + ".json";
+  var wallet;
+  if (!fs.existsSync(seedFilePath)) {
+    console.log("Create Wallet");
+    // Create your first wallet, default wallets created if for Base Sepolia
+    let wallet = await Wallet.create({ networkId: network_id });
+
+    let data = wallet.export();
+    let jsonData = JSON.stringify(data);
+
+    fs.writeFileSync(seedFilePath, jsonData);
+    console.log(
+      `Seed for wallet ${wallet.getId()} successfully saved to ${seedFilePath}.`
+    );
+
+    // Fund your wallet with ETH using a faucet.
+    if (network_id == Coinbase.networks.BaseSepolia) {
+      let faucetEthTransaction = await wallet.faucet();
+      console.log(`Faucet transaction: ${faucetEthTransaction}`);
+    }
+  } else {
+    console.log("Load Wallet");
+    var fetchedData = JSON.parse(fs.readFileSync(seedFilePath, "utf8"));
+    wallet = await Wallet.import({
+      walletId: fetchedData.walletId,
+      seed: fetchedData.seed,
+    });
+  }
+  return { wallet };
 }

--- a/pages/api/sell-config-api.ts
+++ b/pages/api/sell-config-api.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createRequest, fetchOnrampRequest } from "./helpers";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const request_method = "GET";
+  const { url, jwt } = await createRequest({
+    request_method,
+    request_path: "/onramp/v1/sell/config",
+  });
+
+  await fetchOnrampRequest({
+    request_method,
+    url,
+    jwt,
+    res,
+  });
+}

--- a/pages/api/sell-options-api.ts
+++ b/pages/api/sell-options-api.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createRequest, fetchOnrampRequest } from "./helpers";
+import { SellOptionsRequest } from "@/app/utils/types";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const reqBody = JSON.parse(req.body);
+  const body: SellOptionsRequest = {
+    country: reqBody.country,
+    subdivision: reqBody.subdivision,
+  };
+
+  const request_method = "GET";
+
+  let { url, jwt } = await createRequest({
+    request_method,
+    request_path: "/onramp/v1/sell/options",
+  });
+  url = url + `?&country=${body.country}&subdivision=${body.subdivision}`;
+
+  await fetchOnrampRequest({
+    request_method,
+    url,
+    jwt,
+    res,
+  });
+}

--- a/pages/api/sell-quote-api.ts
+++ b/pages/api/sell-quote-api.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createRequest, fetchOnrampRequest } from "./helpers";
+
+type SellQuoteRequest = {
+  sell_currency: string;
+  sell_network: string;
+  sell_amount: string;
+  cashout_currency: string;
+  payment_method: string;
+  country: string;
+  subdivision?: string;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const request_method = "POST";
+  const { url, jwt } = await createRequest({
+    request_method,
+    request_path: "/onramp/v1/sell/quote",
+  });
+
+  const reqBody = JSON.parse(req.body);
+  const body: SellQuoteRequest = {
+    sell_currency: reqBody.sell_currency,
+    sell_amount: reqBody.sell_amount,
+    sell_network: reqBody.sell_network,
+    cashout_currency: reqBody.cashout_currency,
+    payment_method: reqBody.payment_method,
+    country: reqBody.country,
+    subdivision: reqBody.subdivision,
+  };
+
+  await fetchOnrampRequest({
+    request_method,
+    url,
+    jwt,
+    body: JSON.stringify(body),
+    res,
+  });
+}

--- a/pages/api/sell-transaction-status-api.ts
+++ b/pages/api/sell-transaction-status-api.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createRequest, fetchOnrampRequest } from "./helpers";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const reqBody = JSON.parse(req.body);
+  const request_method = "GET";
+  const { url, jwt } = await createRequest({
+    request_method: request_method,
+    request_path:
+      "/onramp/v1/sell/user/" + reqBody.partner_user_id + "/transactions",
+  });
+
+  await fetchOnrampRequest({
+    request_method,
+    url,
+    jwt,
+    res,
+  });
+}


### PR DESCRIPTION
Added a MPC wallet generation for onramp and offramp test

- Create or load existing wallet based on network 
  - Wallet seed will be stored in local file for simplicity
  - Show wallet address and wallet balance

- Create onramp url based on wallet
- Create offramp url based on wallet
- Fetch sell offramp transaction
- Send crypto for offramp

https://github.com/user-attachments/assets/b39f482d-1b39-47cb-a552-691959c8dc4b


